### PR TITLE
Fixed bug where minRows was off by one

### DIFF
--- a/jquery.filtertable.js
+++ b/jquery.filtertable.js
@@ -76,7 +76,7 @@
                 quicks = null, // placeholder for the quick list items
                 filter = null, // placeholder for the field field DOM node
                 created_filter = true; // was the filter created or chosen from an existing element?
-            if (t[0].nodeName==='TABLE' && tbody.length>0 && (settings.minRows===0 || (settings.minRows>0 && tbody.find('tr').length>settings.minRows)) && !t.prev().hasClass(settings.containerClass)) { // only if object is a table and there's a tbody and at least minRows trs and hasn't already had a filter added
+            if (t[0].nodeName==='TABLE' && tbody.length>0 && (settings.minRows===0 || (settings.minRows>0 && tbody.find('tr').length>=settings.minRows)) && !t.prev().hasClass(settings.containerClass)) { // only if object is a table and there's a tbody and at least minRows trs and hasn't already had a filter added
                 if (settings.inputSelector && $(settings.inputSelector).length===1) { // use a single existing field as the filter input field
                     filter = $(settings.inputSelector);
                     container = filter.parent(); // container to hold the quick list options


### PR DESCRIPTION
If the table has minRows or more entries, the filter should appear. Previously, if it had the exact number of rows as minRows, it would not show the filter.