### PR TITLE
Mixed content error preventing jQuery from loading from the CDN

### DIFF
--- a/examples/filtertable-all-terms.html
+++ b/examples/filtertable-all-terms.html
@@ -84,7 +84,7 @@
     <pre>$('table').filterTable({
     filterExpression: 'filterTableFindAll'
 });</pre>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="../jquery.filtertable.min.js"></script>
     <script>
     $(document).ready(function() {

--- a/examples/filtertable-any-term.html
+++ b/examples/filtertable-any-term.html
@@ -81,7 +81,7 @@
     <pre>$('table').filterTable({
     filterExpression: 'filterTableFindAny'
 });</pre>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="../jquery.filtertable.min.js"></script>
     <script>
     $(document).ready(function() {

--- a/examples/filtertable-existing-input.html
+++ b/examples/filtertable-existing-input.html
@@ -80,7 +80,7 @@
     <pre>$('table').filterTable({
     inputSelector: '#input-filter'
 });</pre>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="../jquery.filtertable.min.js"></script>
     <script>
     $(document).ready(function() {

--- a/examples/filtertable-ignore-class.html
+++ b/examples/filtertable-ignore-class.html
@@ -49,7 +49,7 @@
     <pre>$('table').filterTable({
     ignoreClass: 'no-filter'
 });</pre>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="../jquery.filtertable.min.js"></script>
     <script>
     $(document).ready(function() {

--- a/examples/filtertable-ignore-columns.html
+++ b/examples/filtertable-ignore-columns.html
@@ -86,7 +86,7 @@
     <pre>$('table').filterTable({
     ignoreColumns: [0, 2]
 });</pre>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="../jquery.filtertable.min.js"></script>
     <script>
     $(document).ready(function() {

--- a/examples/filtertable-min-chars.html
+++ b/examples/filtertable-min-chars.html
@@ -85,7 +85,7 @@
     minChars: 3,
     label: 'Filter (3+ characters):'
 });</pre>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="../jquery.filtertable.min.js"></script>
     <script>
     $(document).ready(function() {

--- a/examples/filtertable-min-rows.html
+++ b/examples/filtertable-min-rows.html
@@ -81,7 +81,7 @@
     minRows: 0
 });</pre>
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="../jquery.filtertable.min.js"></script>
     <script>
     $(document).ready(function() {

--- a/examples/filtertable-quick.html
+++ b/examples/filtertable-quick.html
@@ -100,7 +100,7 @@
     ]
 });</pre>
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="../jquery.filtertable.min.js"></script>
     <script>
     $(document).ready(function() {

--- a/examples/filtertable-sample.html
+++ b/examples/filtertable-sample.html
@@ -74,7 +74,7 @@
     <p><em>Data as of October, 2012.</em></p>
     <h2>Code</h2>
     <pre>$('table').filterTable();</pre>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="../jquery.filtertable.min.js"></script>
     <script>
     $(document).ready(function() {

--- a/examples/filtertable-striping.html
+++ b/examples/filtertable-striping.html
@@ -85,7 +85,7 @@ $('table').filterTable({
     callback: function(term, table) { stripeTable(table); } //call the striping after every change to the filter term
 });
 stripeTable($('table')); //stripe the table for the first time</pre>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="../jquery.filtertable.min.js"></script>
     <script>
     $(document).ready(function() {


### PR DESCRIPTION
The `http` was hard coded into the examples for the jQuery CDN. When using pages as `https` jQuery will fail to load.

Removed the `http` from the CDN links so it'll use either `http` or `https`.